### PR TITLE
fix bug in calling fetchRecords on a set where all records are identity-mapped

### DIFF
--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -100,6 +100,11 @@ abstract class Mapper
             }
         }
 
+        // early return if all records were identity-mapped
+        if (count($missing) == 0) {
+            return $this->turnRowsIntoRecords($rows, $with);
+        }
+
         // fetch rows missing from identity map
         foreach ($this->table->selectRows($this->select(), $missing) as $row) {
             $serial = $this->identityMap->getSerial($row);


### PR DESCRIPTION
Resolves #9 

I still think we should consider allowing the query builder to write valid SQL when querying for all values in (or not in) an empty set. Especially considering SQLite supports this functionality out of the box, and writing the code that gets the other supported DBs to behave consistently wouldn't be too heavy of a lift.