### PR TITLE
Performance optimisations on stitchIntoRecord

### DIFF
--- a/src/Relationship/ManyToMany.php
+++ b/src/Relationship/ManyToMany.php
@@ -138,7 +138,7 @@ class ManyToMany extends RegularRelationship
 
     protected function stitchIntoRecord(
         Record $nativeRecord,
-        array $foreignRecords
+        array &$foreignRecords
     ) : void
     {
         $matches = $this->getMatches($nativeRecord, $foreignRecords);

--- a/src/Relationship/ManyToOne.php
+++ b/src/Relationship/ManyToOne.php
@@ -27,13 +27,14 @@ class ManyToOne extends RegularRelationship
 
     protected function stitchIntoRecord(
         Record $nativeRecord,
-        array $foreignRecords
+        array &$foreignRecords
     ) : void
     {
         $nativeRecord->{$this->name} = false;
         foreach ($foreignRecords as $foreignRecord) {
             if ($this->recordsMatch($nativeRecord, $foreignRecord)) {
                 $nativeRecord->{$this->name} = $foreignRecord;
+                return;
             }
         }
     }

--- a/src/Relationship/OneToMany.php
+++ b/src/Relationship/OneToMany.php
@@ -18,13 +18,14 @@ class OneToMany extends DeletableRelationship
 {
     protected function stitchIntoRecord(
         Record $nativeRecord,
-        array $foreignRecords
+        array &$foreignRecords
     ) : void
     {
         $matches = [];
-        foreach ($foreignRecords as $foreignRecord) {
+        foreach ($foreignRecords as $index => $foreignRecord) {
             if ($this->recordsMatch($nativeRecord, $foreignRecord)) {
                 $matches[] = $foreignRecord;
+                unset($foreignRecords[$index]);
             }
         }
 

--- a/src/Relationship/OneToOne.php
+++ b/src/Relationship/OneToOne.php
@@ -17,12 +17,14 @@ class OneToOne extends DeletableRelationship
 {
     protected function stitchIntoRecord(
         Record $nativeRecord,
-        array $foreignRecords
+        array &$foreignRecords
     ) : void {
         $nativeRecord->{$this->name} = false;
-        foreach ($foreignRecords as $foreignRecord) {
+        foreach ($foreignRecords as $index => $foreignRecord) {
             if ($this->recordsMatch($nativeRecord, $foreignRecord)) {
                 $nativeRecord->{$this->name} = $foreignRecord;
+                unset($foreignRecords[$index]);
+                return;
             }
         }
     }

--- a/src/Relationship/RegularRelationship.php
+++ b/src/Relationship/RegularRelationship.php
@@ -105,7 +105,7 @@ abstract class RegularRelationship extends Relationship
 
     abstract protected function stitchIntoRecord(
         Record $nativeRecord,
-        array $foreignRecords
+        array &$foreignRecords
     ) : void;
 
     public function joinSelect(

--- a/tests/Fake/FakeRegularRelationship.php
+++ b/tests/Fake/FakeRegularRelationship.php
@@ -14,7 +14,7 @@ class FakeRegularRelationship extends RegularRelationship
 
     protected function stitchIntoRecord(
         Record $nativeRecord,
-        array $foreignRecords
+        array &$foreignRecords
     ) : void {
         return;
     }


### PR DESCRIPTION
This PR suggests some performance optimisations on stitchRecord, as per the discussion in #12. The general approach is:

* Exit the stitchIntoRecord method early when possible.
* Remove foreignRecord entries in stitchIntoRecord once they've been matched, where possible.

I've not analysed/improved many-2-many relationships in this PR but I suspect there is possible further improvement in the case of many-2-1 and many-2-many around keying foreign records on a hash of their match fields to prevent multiple scans through the foreignRecords array. However, this would require a larger re-working on the stitching methods.