### PR TITLE
Pr/multi record stitch optimisations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "atlas/atlas-mapper",
+    "name": "atlas/mapper",
     "type": "library",
     "description": "A data mapper for the persistence model.",
     "keywords": [ "sql", "data", "mapper", "mapping", "orm" ],

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "far-blue/atlas-mapper",
-    "replaces": "atlas/mapper",
     "type": "library",
     "description": "A data mapper for the persistence model.",
     "keywords": [ "sql", "data", "mapper", "mapping", "orm" ],
@@ -30,5 +29,9 @@
         "psr-4": {
             "Atlas\\Mapper\\": "tests/"
         }
+    },
+    "replace": {
+        "atlas/mapper": "1.*"
     }
+
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
-    "name": "atlas/mapper",
+    "name": "far-blue/atlas-mapper",
+    "replaces": "atlas/mapper",
     "type": "library",
     "description": "A data mapper for the persistence model.",
     "keywords": [ "sql", "data", "mapper", "mapping", "orm" ],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "far-blue/atlas-mapper",
+    "name": "atlas/atlas-mapper",
     "type": "library",
     "description": "A data mapper for the persistence model.",
     "keywords": [ "sql", "data", "mapper", "mapping", "orm" ],
@@ -29,9 +29,5 @@
         "psr-4": {
             "Atlas\\Mapper\\": "tests/"
         }
-    },
-    "replace": {
-        "atlas/mapper": "1.*"
     }
-
 }

--- a/src/Relationship/OneToMany.php
+++ b/src/Relationship/OneToMany.php
@@ -16,6 +16,35 @@ use SplObjectStorage;
 
 class OneToMany extends DeletableRelationship
 {
+    public function stitchIntoRecords(
+        array $nativeRecords,
+        callable $custom = null
+    ) : void
+    {
+        if (empty($nativeRecords)) {
+            return;
+        }
+
+         $foreignRecords = $this->fetchForeignRecords($nativeRecords, $custom);
+
+        $foreignRecordHashes = [];
+        $foreignMatchColumns = array_values($this->on);
+        foreach ($foreignRecords as $foreignRecord) {
+            $foreignHash = $this->generateMatchHash($foreignRecord, $foreignMatchColumns);
+            if (!isset($foreignRecordHashes[$foreignHash])) {
+                $foreignRecordHashes[$foreignHash] = [];
+            }
+            $foreignRecordHashes[$foreignHash][] = $foreignRecord;
+        }
+
+        $nativeMatchColumns = array_keys($this->on);
+        foreach ($nativeRecords as $nativeRecord) {
+            $nativeHash = $this->generateMatchHash($nativeRecord, $nativeMatchColumns);
+            $nativeRecord->{$this->name} = $this->getForeignMapper()
+                ->newRecordSet($foreignRecordHashes[$nativeHash] ?? []);
+        }
+    }
+
     protected function stitchIntoRecord(
         Record $nativeRecord,
         array &$foreignRecords

--- a/src/Relationship/RegularRelationship.php
+++ b/src/Relationship/RegularRelationship.php
@@ -204,4 +204,25 @@ abstract class RegularRelationship extends Relationship
         // are they equal?
         return $nativeVal == $foreignVal;
     }
+
+    protected function generateMatchHash(Record $record, array $colNames): string
+    {
+        if (empty($colNames)) {
+            return '';
+        }
+
+        $row = $record->getRow();
+        $matchData = [];
+        $numerics = [];
+        foreach ($colNames as $col) {
+            $value = $row->$col;
+            if (is_numeric($value)) {
+                $numerics[] = $col;
+            } elseif ($this->ignoreCase) {
+                $value = strtolower($value);
+            }
+            $matchData[] = $value;
+        }
+        return sha1(implode('', $matchData)) . sha1(implode('', $numerics));
+    }
 }


### PR DESCRIPTION
This PR addresses some performance issues with large many-to-many datasets.

As an example:

We have 3 tables - ports, destinations and a ports-destinations many-to-many linking table. We have ~ 4500 ports and ~ 400 destinations and ports are linked to an average of 1.2 destinations (~ 80% of ports are only in 1 destination).

The existing code takes approx. 40 seconds to return a complete json structure based on this data. Profiling showed that approx. 1.2 million calls to RegularRelationship.php's `recordsMatch` method were being made via OneToMany.php's `stitchIntoRecords` method and then an additional 1.4 million calls to RegularRelationship.php's `recordsMatch` method were being made via OneToOne.php's `stitchIntoRecords` method.

The reason for this is that for each port object the code loops through every port-destination linking object and attempts to match it. Being a one-to-many call we can't exit early so every relation needs to be checked. Once every linking object has been found there is a further loop to find all the records in the destinations table that relate to the linking record using OneToOne relations.

Each call to recordsMatch is pretty quick but 3 million calls to any class method in php isn't going to be the fastest, esp. when `__get` magic method calls are involved. The real problem is that the same records are being repeatedly matched in a 2-level foreach loop and there's no caching of the values being used to do the matching so they are being recalculated millions of times.

This PR addresses these issues by replacing the `stitchIntoRecords` methods for the OneToMany and OneToOne relationship classes. These new methods first make a single pass through the foreign records to calculate a hash of the values that record would previously have been matched on in the `recordsMatch` call. The foreign records are then keyed on this hash in an array. Next, a single pass through the native records generates the same hash and then checks in the hash-keyed foreign record array for matches. Where there's a match the foreign record(s) are matched up to the native record just like they would have been in the original code.

The result of the new methods is a drop in our testing from 40 seconds to 5 seconds for the described data sets.

All thoughts and comments appreciated to improve this PR!