### PR TITLE
add test for #16

### DIFF
--- a/src/Relationship/OneToMany.php
+++ b/src/Relationship/OneToMany.php
@@ -61,5 +61,7 @@ class OneToMany extends DeletableRelationship
         foreach ($foreignRecordSet as $foreignRecord) {
             $foreignMapper->persist($foreignRecord, $tracker);
         }
+
+        $foreignRecordSet->detachDeleted();
     }
 }

--- a/tests/Relationship/ManyToManyTest.php
+++ b/tests/Relationship/ManyToManyTest.php
@@ -25,6 +25,10 @@ class ManyToManyTest extends RelationshipTest
             ->select()
             ->fetchRecordSet();
 
+        // make sure there are three taggings and tags
+        $this->assertCount(3, $before->tags);
+        $this->assertCount(3, $before->taggings);
+
         // remove tag 'foo'
         $before->tags->detachOneBy(['name' => 'foo']);
 
@@ -34,6 +38,10 @@ class ManyToManyTest extends RelationshipTest
 
         // persist it
         $threadMapper->persist($before);
+
+        // make sure the taggings are detached properly
+        $this->assertCount(3, $before->tags);
+        $this->assertCount(3, $before->taggings);
 
         // re-get the thread, with new taggings
         $after = $threadMapper->fetchRecord(1, [
@@ -130,6 +138,31 @@ class ManyToManyTest extends RelationshipTest
         });
 
         $this->assertEquals($expect, $actual);
+    }
+
+    public function testForeignPersist_detachAll()
+    {
+        $threadMapper = $this->mapperLocator->get(Thread::CLASS);
+
+        $before = $threadMapper->fetchRecord(1, [
+            'tags'
+        ]);
+
+        $this->assertCount(3, $before->taggings);
+        $this->assertCount(3, $before->tags);
+
+        $before->tags->detachAll();
+        $threadMapper->persist($before);
+
+        $this->assertCount(0, $before->tags);
+        $this->assertCount(0, $before->taggings);
+
+        $after = $threadMapper->fetchRecord(1, [
+            'tags'
+        ]);
+
+        $this->assertCount(0, $after->taggings);
+        $this->assertCount(0, $after->tags);
     }
 
     public function testJoinSelect()


### PR DESCRIPTION
@jakejohns @far-blue This adds a test for #16, and a new behavior.

Previously, detaching a foreign record in a many-to-many (e.g., a foreign tag on a native thread) would leave the in-memory through record in place (e.g., the through tagging for that foreign tag). Thus, if you had three tags, and detached them all, there would still be three taggings in memory (though not at the database). I had not noticed this behavior before, and found it surprising.

The new behavior is that the one-to-many relationship, after persisting, will detach its deleted in-memory records. This means, in the above example, that there would be no taggings in memory any more, which I think would be expected after you remove the tags from the thread.

Thoughts?