### PR TITLE
provide a method to publicly access the foreign mapper class name string on relationships.

### DIFF
--- a/src/Relationship/Relationship.php
+++ b/src/Relationship/Relationship.php
@@ -35,6 +35,11 @@ abstract class Relationship
         return $this;
     }
 
+    public function getForeignMapperClass() : string
+    {
+        return $this->foreignMapperClass;
+    }
+
     abstract public function joinSelect(
         MapperSelect $select,
         string $join,


### PR DESCRIPTION
A small PR to add a public method giving access to the foreignMapperClass string. This will allow for easier creation of records and record sets of the correct foreign record type when creating empty records with relations.